### PR TITLE
Fix wayland-egl support on Mesa

### DIFF
--- a/src/wayland-egl/renderer-backend.cpp
+++ b/src/wayland-egl/renderer-backend.cpp
@@ -26,13 +26,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <wayland-egl.h>
+
 #include <wpe/renderer-backend-egl.h>
 
 #include "display.h"
 #include "ipc.h"
 #include "ipc-waylandegl.h"
 #include <wayland-client-protocol.h>
-#include <wayland-egl.h>
 
 namespace WaylandEGL {
 


### PR DESCRIPTION
The wayland-egl.h header must be included before eglplatform.h since we
need the WL_EGL_PLATFORM define to have the correct EGLNative*Type types.

We need to use EGL_KHR_surfaceless_context for offscreen contexts,
since Mesa does not support pbuffers on wayland.