### PR TITLE
Revert "Correcting XKB key mapping for XKB_KEY_XF86AudioPlay and XKB_…

### DIFF
--- a/src/input/XKB/input-libxkbcommon.cpp
+++ b/src/input/XKB/input-libxkbcommon.cpp
@@ -287,9 +287,8 @@ struct wpe_input_key_mapper_interface libxkbcommon_input_key_mapper_interface = 
                 // VK_MENU (12) ALT key
 
             case XKB_KEY_Pause:
-                return VK_PAUSE; // (13) PAUSE key
             case XKB_KEY_XF86AudioPause:
-                return VK_MEDIA_PLAY_PAUSE; // (B3) Windows 2000/XP: Play/Pause Media key
+                return VK_PAUSE; // (13) PAUSE key
             case XKB_KEY_Caps_Lock:
                 return VK_CAPITAL; // (14) CAPS LOCK key
             case XKB_KEY_Kana_Lock:
@@ -570,7 +569,7 @@ struct wpe_input_key_mapper_interface libxkbcommon_input_key_mapper_interface = 
                 // VK_EXSEL (F8) ExSel key
                 // VK_EREOF (F9) Erase EOF key
             case XKB_KEY_XF86AudioPlay:
-                return VK_MEDIA_PLAY_PAUSE; // (B3) Windows 2000/XP: Play/Pause Media key
+                return VK_PLAY; // VK_PLAY (FA) Play key
                 // VK_ZOOM (FB) Zoom key
                 // VK_NONAME (FC) Reserved for future use
                 // VK_PA1 (FD) PA1 key


### PR DESCRIPTION
…KEY_XF86AudioPause to use"

Play, Pause and PlayPause are 3 different keys.
The PlayPause keycode should not be used for Play or Pause keys.

This reverts commit 11ee02c4e96dc3223f332fe1f849f05d0ee644e5.