### PR TITLE
Add wayland input support in bcm-nexus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ option(USE_BACKEND_WESTEROS_MESA "Whether to enable support for the gbm based of
 
 option(USE_INPUT_LIBINPUT "Whether to enable support for the libinput input backend" ON)
 option(USE_INPUT_UDEV "Whether to enable support for the libinput input udev lib" ON)
+option(USE_INPUT_WAYLAND "Whether to enable support for the wayland input backend" OFF)
 set(USE_KEY_INPUT_HANDLING_LINUX_INPUT OFF CACHE BOOL "Whether to use <linux/input.h> event codes for keyboard event handling")
 
 find_package(WPE REQUIRED)

--- a/src/bcm-nexus/CMakeLists.txt
+++ b/src/bcm-nexus/CMakeLists.txt
@@ -16,3 +16,7 @@ list(APPEND WPE_PLATFORM_SOURCES
     src/bcm-nexus/renderer-backend.cpp
     src/bcm-nexus/view-backend.cpp
 )
+
+if (USE_INPUT_LIBINPUT)
+    add_definitions(-DKEY_INPUT_HANDLING_LIBINPUT=1)
+endif ()

--- a/src/bcm-nexus/CMakeLists.txt
+++ b/src/bcm-nexus/CMakeLists.txt
@@ -20,3 +20,23 @@ list(APPEND WPE_PLATFORM_SOURCES
 if (USE_INPUT_LIBINPUT)
     add_definitions(-DKEY_INPUT_HANDLING_LIBINPUT=1)
 endif ()
+
+if (USE_INPUT_WAYLAND)
+    add_definitions(-DKEY_INPUT_HANDLING_WAYLAND=1)
+
+    find_package(Wayland REQUIRED)
+    list(APPEND WPE_PLATFORM_INCLUDE_DIRECTORIES
+        "${CMAKE_SOURCE_DIR}/src/wayland"
+        "${CMAKE_SOURCE_DIR}/src/wayland/protocols"
+        ${WAYLAND_INCLUDE_DIRS}
+    )
+
+    list(APPEND WPE_PLATFORM_LIBRARIES
+        ${WAYLAND_LIBRARIES}
+    )
+
+    list(APPEND WPE_PLATFORM_SOURCES
+        src/wayland/protocols/xdg-shell-protocol.c
+        src/wayland/display.cpp
+    )
+endif ()


### PR DESCRIPTION
This allows running a WPE browser on top of BCM Nexus for graphical rendering, and using input from a wayland compositor.
This is useful when the system has a wayland compositor with non-standard graphical protocols.