### PR TITLE
libinput: ensure slot id is always a non negative number

### DIFF
--- a/src/input/Libinput/LibinputServer.cpp
+++ b/src/input/Libinput/LibinputServer.cpp
@@ -307,7 +307,7 @@ void LibinputServer::handleTouchEvent(struct libinput_event *event, enum wpe_inp
 {
     auto* touchEvent = libinput_event_get_touch_event(event);
     uint32_t time = libinput_event_touch_get_time(touchEvent);
-    int id = libinput_event_touch_get_slot(touchEvent);
+    int id = libinput_event_touch_get_seat_slot(touchEvent);
     auto& targetPoint = m_touchEvents[id];
     int32_t x, y;
     


### PR DESCRIPTION
If the touchscreen is a single touch device, `get_slot()` will return -1,
and touch events won't work.

`get_seat_slot()` returns a seat-wide non-negative unique identifier for
the touch that can be used to index the `m_touchEvents` array.

Doc reference: https://wayland.freedesktop.org/libinput/doc/latest/group__event__touch.html#gabac75c78a0a360995e1a521edb38c4da