### PR TITLE
[linuxinput] add missing characters

### DIFF
--- a/src/input/LinuxInput/KeyboardEventHandlerLinuxInput.cpp
+++ b/src/input/LinuxInput/KeyboardEventHandlerLinuxInput.cpp
@@ -67,18 +67,18 @@ static uint32_t keyCodeToUTF32(uint32_t key, bool state)
     std::once_flag flag;
     std::call_once(flag, [] {
         table[ KEY_ESC        ] /* 1   */ = { 0x001B                                     , 0 };
-        table[ KEY_1          ] /* 2   */ = { 0x0031 /* U+0031 1 Digit One            */ , 0 };
-        table[ KEY_2          ] /* 3   */ = { 0x0032 /* U+0032 2 Digit Two            */ , 0 };
-        table[ KEY_3          ] /* 4   */ = { 0x0033 /* U+0033 3 Digit Three          */ , 0 };
-        table[ KEY_4          ] /* 5   */ = { 0x0034 /* U+0034 4 Digit Four           */ , 0 };
-        table[ KEY_5          ] /* 6   */ = { 0x0035 /* U+0035 5 Digit Five           */ , 0 };
-        table[ KEY_6          ] /* 7   */ = { 0x0036 /* U+0036 6 Digit Six            */ , 0 };
-        table[ KEY_7          ] /* 8   */ = { 0x0037 /* U+0037 7 Digit Seven          */ , 0 };
-        table[ KEY_8          ] /* 9   */ = { 0x0038 /* U+0038 8 Digit Eight          */ , 0 };
-        table[ KEY_9          ] /* 10  */ = { 0x0039 /* U+0039 9 Digit Nine           */ , 0 };
-        table[ KEY_0          ] /* 11  */ = { 0x0030 /* U+0030 0 Digit Zero           */ , 0 };
-        table[ KEY_MINUS      ] /* 12  */ = { 0x002D /* U+002D - Hyphen-minus         */ , 0 };
-        table[ KEY_EQUAL      ] /* 13  */ = { 0x003D /* U+003D = Equal sign           */ , 0 };
+        table[ KEY_1          ] /* 2   */ = { 0x0031 /* U+0031 1 Digit One            */ , 0x0021 /* U+0021 ! Exclamation Mark       */ };
+        table[ KEY_2          ] /* 3   */ = { 0x0032 /* U+0032 2 Digit Two            */ , 0x0040 /* U+0040 @ Commercial At          */ };
+        table[ KEY_3          ] /* 4   */ = { 0x0033 /* U+0033 3 Digit Three          */ , 0x0023 /* U+0023 # Number Sign            */ };
+        table[ KEY_4          ] /* 5   */ = { 0x0034 /* U+0034 4 Digit Four           */ , 0x0024 /* U+0024 $ Dollar Sign            */ };
+        table[ KEY_5          ] /* 6   */ = { 0x0035 /* U+0035 5 Digit Five           */ , 0x0025 /* U+0025 % Percent Sign           */ };
+        table[ KEY_6          ] /* 7   */ = { 0x0036 /* U+0036 6 Digit Six            */ , 0x005E /* U+005E ^ Circumflex Accent      */ };
+        table[ KEY_7          ] /* 8   */ = { 0x0037 /* U+0037 7 Digit Seven          */ , 0x0026 /* U+0026 & Ampersand              */ };
+        table[ KEY_8          ] /* 9   */ = { 0x0038 /* U+0038 8 Digit Eight          */ , 0x002A /* U+002A * Asterisk               */ };
+        table[ KEY_9          ] /* 10  */ = { 0x0039 /* U+0039 9 Digit Nine           */ , 0x0028 /* U+0028 ( Left Parenthesis       */ };
+        table[ KEY_0          ] /* 11  */ = { 0x0030 /* U+0030 0 Digit Zero           */ , 0x0029 /* U+0029 ) Right Parenthesis      */ };
+        table[ KEY_MINUS      ] /* 12  */ = { 0x002D /* U+002D - Hyphen-minus         */ , 0x005F /* U+005F _ Low Line               */ };
+        table[ KEY_EQUAL      ] /* 13  */ = { 0x003D /* U+003D = Equal sign           */ , 0x002B /* U+002B + Plus Sign              */ };
         table[ KEY_BACKSPACE  ] /* 14  */ = { 0x0008                                     , 0 };
         table[ KEY_TAB        ] /* 15  */ = { 0x0009 /* U+0009 Horizontal tab HT      */ , 0 };
         table[ KEY_Q          ] /* 16  */ = { 0x0071 /* U+0071 q Latin Small Letter Q */ , 0x0051 /* U+0051 Q Latin Capital letter Q */ };
@@ -91,8 +91,8 @@ static uint32_t keyCodeToUTF32(uint32_t key, bool state)
         table[ KEY_I          ] /* 23  */ = { 0x0069 /* U+0069 i Latin Small Letter I */ , 0x0049 /* U+0049 I Latin Capital letter I */ };
         table[ KEY_O          ] /* 24  */ = { 0x006F /* U+006F o Latin Small Letter O */ , 0x004F /* U+004F O Latin Capital letter O */ };
         table[ KEY_P          ] /* 25  */ = { 0x0070 /* U+0070 p Latin Small Letter P */ , 0x0050 /* U+0050 P Latin Capital letter P */ };
-        table[ KEY_LEFTBRACE  ] /* 26  */ = { 0x007B /* U+007B Left Curly Bracket     */ , 0 };
-        table[ KEY_RIGHTBRACE ] /* 27  */ = { 0x007D /* U+007D } Right Curly Bracket  */ , 0 };
+        table[ KEY_LEFTBRACE  ] /* 26  */ = { 0x005B /* U+005B [ Left Square Bracket  */ , 0x007B /* U+007B { Left Curly Bracket     */ };
+        table[ KEY_RIGHTBRACE ] /* 27  */ = { 0x005D /* U+005D ] Right Square Bracket */ , 0x007D /* U+007D } Right Curly Bracket    */ };
 
         table[ KEY_A          ] /* 30  */ = { 0x0061 /* U+0061 a Latin Small Letter A */ , 0x0041 /* U+0041 A Latin Capital letter A */ };
         table[ KEY_S          ] /* 31  */ = { 0x0073 /* U+0073 s Latin Small Letter S */ , 0x0053 /* U+0053 S Latin Capital letter S */ };
@@ -103,11 +103,11 @@ static uint32_t keyCodeToUTF32(uint32_t key, bool state)
         table[ KEY_J          ] /* 36  */ = { 0x006A /* U+006A j Latin Small Letter J */ , 0x004A /* U+004A J Latin Capital letter J */ };
         table[ KEY_K          ] /* 37  */ = { 0x006B /* U+006B k Latin Small Letter K */ , 0x004B /* U+004B K Latin Capital letter K */ };
         table[ KEY_L          ] /* 38  */ = { 0x006C /* U+006C l Latin Small Letter L */ , 0x004C /* U+004C L Latin Capital letter L */ };
-        table[ KEY_SEMICOLON  ] /* 39  */ = { 0x003B /* U+003B ; Semicolon            */ , 0 };
-        table[ KEY_APOSTROPHE ] /* 40  */ = { 0x0027 /* U+0027 ' Apostrophe           */ , 0 };
-        table[ KEY_GRAVE      ] /* 41  */ = { 0x0060 /* U+0060 ` Grave accent         */ , 0 };
+        table[ KEY_SEMICOLON  ] /* 39  */ = { 0x003B /* U+003B ; Semicolon            */ , 0x003A /* U+003A : Colon                  */ };
+        table[ KEY_APOSTROPHE ] /* 40  */ = { 0x0027 /* U+0027 ' Apostrophe           */ , 0x0022 /* U+0022 " Quotation Mark         */ };
+        table[ KEY_GRAVE      ] /* 41  */ = { 0x0060 /* U+0060 ` Grave accent         */ , 0x007E /* U+007E ~ Tilde                  */ };
 
-        table[ KEY_BACKSLASH  ] /* 43  */ = { 0x005C /* U+005C \ Backslash            */ , 0 };
+        table[ KEY_BACKSLASH  ] /* 43  */ = { 0x005C /* U+005C \ Backslash            */ , 0x007C /* U+007C | Vertical Line          */ };
         table[ KEY_Z          ] /* 44  */ = { 0x007A /* U+007A z Latin Small Letter Z */ , 0x005A /* U+005A Z Latin Capital letter Z */ };
         table[ KEY_X          ] /* 45  */ = { 0x0078 /* U+0078 x Latin Small Letter X */ , 0x0058 /* U+0058 X Latin Capital letter X */ };
         table[ KEY_C          ] /* 46  */ = { 0x0063 /* U+0063 c Latin Small Letter C */ , 0x0043 /* U+0043 C Latin Capital letter C */ };
@@ -115,9 +115,9 @@ static uint32_t keyCodeToUTF32(uint32_t key, bool state)
         table[ KEY_B          ] /* 48  */ = { 0x0062 /* U+0062 b Latin Small Letter B */ , 0x0042 /* U+0042 B Latin Capital letter B */ };
         table[ KEY_N          ] /* 49  */ = { 0x006E /* U+006E n Latin Small Letter N */ , 0x004E /* U+004E N Latin Capital letter N */ };
         table[ KEY_M          ] /* 50  */ = { 0x006D /* U+006D m Latin Small Letter M */ , 0x004D /* U+004D M Latin Capital letter M */ };
-        table[ KEY_COMMA      ] /* 51  */ = { 0x002C /* U+002C , 0, Comma             */ , 0 };
-        table[ KEY_DOT        ] /* 52  */ = { 0x002E /* U+002E . Full stop            */ , 0 };
-        table[ KEY_SLASH      ] /* 53  */ = { 0x002F /* U+002F / Slash                */ , 0 };
+        table[ KEY_COMMA      ] /* 51  */ = { 0x002C /* U+002C , Comma                */ , 0x003C /* U+003C < Less-than Sign         */ };
+        table[ KEY_DOT        ] /* 52  */ = { 0x002E /* U+002E . Full stop            */ , 0x003E /* U+003E > Greater-than Sign      */ };
+        table[ KEY_SLASH      ] /* 53  */ = { 0x002F /* U+002F / Slash                */ , 0x003F /* U+003F ? Question Mark          */ };
 
         table[ KEY_SPACE      ] /* 57  */ = { 0x0020 /* U+0020 Space SP               */ , 0 };
     });


### PR DESCRIPTION
The LinuxInput driver was missing characters and also had incorrectly mapped `[]` to `{}`.

Connects-to: https://github.com/resin-io-playground/resin-wpe/issues/5