### PR TITLE
westeros: perform more robust wayland event dispatching

### DIFF
--- a/src/westeros/renderer-backend.cpp
+++ b/src/westeros/renderer-backend.cpp
@@ -35,6 +35,12 @@
 #include <wayland-client.h>
 #include <wayland-egl.h>
 
+#ifndef NDEBUG
+#define DEBUG_PRINT(...) fprintf(stderr, __VA_ARGS__)
+#else
+#define DEBUG_PRINT(...) (void(0))
+#endif
+
 #if defined(WPE_BACKEND_MESA)
 #include <gbm.h>
 #include <fcntl.h>
@@ -60,12 +66,12 @@ struct EGLOffscreenTarget {
        if (device)
            surface = gbm_surface_create(device, width, height, GBM_FORMAT_XRGB8888, GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING);
        else{
-           printf("EGLOffscreenTarget: gbm device is null\n");
+           DEBUG_PRINT("EGLOffscreenTarget: gbm device is null\n");
            return;
        }
 
        if (!surface)
-           printf("EGLOffscreenTarget: gbm surface created failed\n");
+           DEBUG_PRINT("EGLOffscreenTarget: gbm surface created failed\n");
     }
 };
 
@@ -74,13 +80,13 @@ struct Backend {
     {
         fd = open(DEFAULT_CARD, O_RDWR | O_CLOEXEC | O_NOCTTY | O_NONBLOCK);
         if (fd < 0){
-            printf("Backend: DRM device open failure\n");
+            DEBUG_PRINT("Backend: DRM device open failure\n");
             return;
         }
 
         device = gbm_create_device(fd);
         if (!device) {
-            printf("Backend: gbm device not created\n");
+            DEBUG_PRINT("Backend: gbm device not created\n");
             close(fd);
             return;
         }
@@ -123,7 +129,7 @@ GSourceFuncs EventSource::sourceFuncs = {
 
         while (wl_display_prepare_read(display) != 0) {
             if (wl_display_dispatch_pending(display) < 0) {
-                printf("Wayland::Display: error in wayland prepare\n");
+                DEBUG_PRINT("Wayland::Display: error in wayland prepare\n");
                 return FALSE;
             }
         }
@@ -139,7 +145,7 @@ GSourceFuncs EventSource::sourceFuncs = {
 
         if (source->pfd.revents & G_IO_IN) {
             if (wl_display_read_events(display) < 0) {
-                printf("Wayland::Display: error in wayland read\n");
+                DEBUG_PRINT("Wayland::Display: error in wayland read\n");
                 return FALSE;
             }
             return TRUE;
@@ -156,7 +162,7 @@ GSourceFuncs EventSource::sourceFuncs = {
 
         if (source->pfd.revents & G_IO_IN) {
             if (wl_display_dispatch_pending(display) < 0) {
-                printf("Wayland::Display: error in wayland dispatch\n");
+                DEBUG_PRINT("Wayland::Display: error in wayland dispatch\n");
                 return G_SOURCE_REMOVE;
             }
         }
@@ -431,7 +437,7 @@ struct wpe_renderer_backend_egl_offscreen_target_interface westeros_renderer_bac
     {
 #if defined(WPE_BACKEND_MESA)        
         auto* target = static_cast<GBM::EGLOffscreenTarget*>(data);
-        printf("westeros_renderer_backend_egl_offscreen_target_interface: native window %x\n", target->surface);
+        DEBUG_PRINT("westeros_renderer_backend_egl_offscreen_target_interface: native window %x\n", target->surface);
         return (EGLNativeWindowType)target->surface;
 #else
         return (EGLNativeWindowType)nullptr;

--- a/src/westeros/renderer-backend.cpp
+++ b/src/westeros/renderer-backend.cpp
@@ -120,8 +120,14 @@ GSourceFuncs EventSource::sourceFuncs = {
         struct wl_display* display = source->display;
 
         *timeout = -1;
+
+        while (wl_display_prepare_read(display) != 0) {
+            if (wl_display_dispatch_pending(display) < 0) {
+                printf("Wayland::Display: error in wayland prepare\n");
+                return FALSE;
+            }
+        }
         wl_display_flush(display);
-        wl_display_dispatch_pending(display);
 
         return FALSE;
     },
@@ -129,7 +135,18 @@ GSourceFuncs EventSource::sourceFuncs = {
     [](GSource* base) -> gboolean
     {
         auto* source = reinterpret_cast<EventSource*>(base);
-        return !!source->pfd.revents;
+        struct wl_display* display = source->display;
+
+        if (source->pfd.revents & G_IO_IN) {
+            if (wl_display_read_events(display) < 0) {
+                printf("Wayland::Display: error in wayland read\n");
+                return FALSE;
+            }
+            return TRUE;
+        } else {
+            wl_display_cancel_read(display);
+            return FALSE;
+        }
     },
     // dispatch
     [](GSource* base, GSourceFunc, gpointer) -> gboolean
@@ -137,14 +154,18 @@ GSourceFuncs EventSource::sourceFuncs = {
         auto* source = reinterpret_cast<EventSource*>(base);
         struct wl_display* display = source->display;
 
-        if (source->pfd.revents & G_IO_IN)
-            wl_display_dispatch(display);
+        if (source->pfd.revents & G_IO_IN) {
+            if (wl_display_dispatch_pending(display) < 0) {
+                printf("Wayland::Display: error in wayland dispatch\n");
+                return G_SOURCE_REMOVE;
+            }
+        }
 
         if (source->pfd.revents & (G_IO_ERR | G_IO_HUP))
-            return FALSE;
+            return G_SOURCE_REMOVE;
 
         source->pfd.revents = 0;
-        return TRUE;
+        return G_SOURCE_CONTINUE;
     },
     nullptr, // finalize
     nullptr, // closure_callback


### PR DESCRIPTION
In order to avoid potential lockups in handling Wayland protocol event
dispatching, adopt the same procedures that are used in
src/wayland/display.cpp. EventSource callbacks are enhanced:
- prepare() now dispatches pending events as long as there are
prepared events being provided,
- check() returns TRUE if new events can in fact be read,
- dispatch() only dispatches the pending events.

Previous code was prone to race conditions that occur while reading
from wl_display and dispatching those read events. Here we do this by
leveraging the default dispatch queue, but other components (e.g. the
graphics drivers or Westeros) are utilizing the same Wayland display
connection through different dispatch queues on other threads.
Previous code was thus prone to thread lockups, while these changes
take up the approach already utilized by other Wayland backends via
Wayland::EventSource::sourceFuncs (src/wayland/display.cpp).

More detail on this issue and the appropriate approach is described
in the Wayland documentation:
https://wayland.freedesktop.org/docs/html/apb.html#Client-classwl__display

This attempts to address lockups that are reported in issue #430 of
the WPEWebKit repository.
https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/430