### PR TITLE
bcm-nexus: remove unused Nexus variables

### DIFF
--- a/src/bcm-nexus/renderer-backend.cpp
+++ b/src/bcm-nexus/renderer-backend.cpp
@@ -49,12 +49,6 @@ struct Backend {
     ~Backend();
 
     NXPL_PlatformHandle nxplHandle;
-
-    NEXUS_GraphicsSettings graphicsSettings;
-    NEXUS_DisplayHandle display;
-    NEXUS_Error rc;
-
-    NEXUS_SurfaceClientHandle client;
 };
 
 Backend::Backend()


### PR DESCRIPTION
cc @wouterlucas 