### PR TITLE
viv-imx6 backend honors WPE_INIT_VIEW (WIDTH,HEIGHT) envvars

### DIFF
--- a/src/viv-imx6/view-backend.cpp
+++ b/src/viv-imx6/view-backend.cpp
@@ -79,6 +79,19 @@ ViewBackend::~ViewBackend()
 
 void ViewBackend::initialize()
 {
+    uint32_t width = WIDTH, height = HEIGHT;
+    char *tmp;
+
+    if (tmp = std::getenv("WPE_INIT_VIEW_WIDTH")) {
+        width = atoi(tmp);
+        this->width = { width };
+    };
+
+    if (tmp = std::getenv("WPE_INIT_VIEW_HEIGHT")) {
+        height = atoi(tmp);
+        this->height = { height };
+    };
+
     wpe_view_backend_dispatch_set_size(backend, width, height);
 
     WPE::LibinputServer::singleton().setClient(this);


### PR DESCRIPTION
For example:

  export WPE_INIT_VIEW_HEIGHT=1080
  export WPE_INIT_VIEW_WIDTH=1920

Signed-off-by: Pablo Saavedra <psaavedra@igalia.com>