### PR TITLE
Adapt to WPEBackend -> libwpe change and increase version to libwpe-0.2

### DIFF
--- a/cmake/FindWPE.cmake
+++ b/cmake/FindWPE.cmake
@@ -29,7 +29,7 @@
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 find_package(PkgConfig)
-pkg_check_modules(PC_WPE QUIET wpe-0.1)
+pkg_check_modules(PC_WPE QUIET wpe-0.2)
 
 find_path(WPE_INCLUDE_DIRS
     NAMES wpe/wpe.h
@@ -37,7 +37,7 @@ find_path(WPE_INCLUDE_DIRS
 )
 
 find_library(WPE_LIBRARIES
-    NAMES WPEBackend-0.1
+    NAMES wpe-0.2
     HINTS ${PC_WPE_LIBDIR} ${PC_WPE_LIBRARY_DIRS}
 )
 


### PR DESCRIPTION
WPEBackend changed name to libwpe, current version is 1.0.0
However, internally (pkg-conf) version has API-version, which is 0.2.
