### PR TITLE
Fix missing return value

### DIFF
--- a/src/westeros/WesterosViewbackendInput.cpp
+++ b/src/westeros/WesterosViewbackendInput.cpp
@@ -144,7 +144,7 @@ void WesterosViewbackendInput::handleKeyEvent(void* userData, uint32_t key, uint
 
         uint32_t keysym = wpe_input_xkb_context_get_key_code(wpe_input_xkb_context_get_default(), e->key, e->state == WL_KEYBOARD_KEY_STATE_PRESSED);
         if (!keysym)
-            return;
+            return 0;
 
         struct wpe_input_keyboard_event event
                 { e->time, keysym, e->key, !!e->state, handlerData.modifiers };


### PR DESCRIPTION
Fix am implicit (missing) return value prevent compilation on newer versions of gcc.

https://github.com/WebPlatformForEmbedded/meta-wpe/issues/236