### PR TITLE
return boolean value instead of void

### DIFF
--- a/src/westeros/WesterosViewbackendInput.cpp
+++ b/src/westeros/WesterosViewbackendInput.cpp
@@ -144,7 +144,10 @@ void WesterosViewbackendInput::handleKeyEvent(void* userData, uint32_t key, uint
 
         uint32_t keysym = wpe_input_xkb_context_get_key_code(wpe_input_xkb_context_get_default(), e->key, e->state == WL_KEYBOARD_KEY_STATE_PRESSED);
         if (!keysym)
-            return;
+        {
+            delete e;
+            return G_SOURCE_REMOVE;
+        }
 
         struct wpe_input_keyboard_event event
                 { e->time, keysym, e->key, !!e->state, handlerData.modifiers };


### PR DESCRIPTION
Returning boolean value as it supposed to be.

Signed-off-by: mgopal003c <Manigandan_Gopalakirshnan@cable.comcast.com>