### PR TITLE
Fix buffer overflow when sending input event messages

### DIFF
--- a/src/bcm-nexus-wayland/ipc-bcmnexuswl.h
+++ b/src/bcm-nexus-wayland/ipc-bcmnexuswl.h
@@ -40,7 +40,7 @@ struct TargetConstruction {
     uint32_t handle;
     uint32_t width;
     uint32_t height;
-    uint8_t padding[12];
+    uint8_t padding[20];
 
     static const uint64_t code = 1;
     static void construct(Message& message, uint32_t handle, uint32_t width, uint32_t height)
@@ -62,7 +62,7 @@ static_assert(sizeof(TargetConstruction) == Message::dataSize, "TargetConstructi
 struct Authentication {
     uint32_t authDataSize;
     uint32_t chunkSize;
-    uint8_t data[16];
+    uint8_t data[24];
 
     static const uint64_t code = 2;
     static const size_t maxChunkSize = 16;
@@ -85,7 +85,7 @@ static_assert(sizeof(Authentication) == Message::dataSize, "Authentication is of
 struct BufferCommit {
     uint32_t width;
     uint32_t height;
-    uint8_t padding[16];
+    uint8_t padding[24];
 
     static const uint64_t code = 3;
     static void construct(Message& message, uint32_t width, uint32_t height)
@@ -104,7 +104,7 @@ struct BufferCommit {
 static_assert(sizeof(BufferCommit) == Message::dataSize, "BufferCommit is of correct size");
 
 struct FrameComplete {
-    int8_t padding[24];
+    int8_t padding[32];
 
     static const uint64_t code = 4;
     static void construct(Message& message)

--- a/src/bcm-nexus/ipc-bcmnexus.h
+++ b/src/bcm-nexus/ipc-bcmnexus.h
@@ -38,7 +38,7 @@ namespace BCMNexus {
 struct BufferCommit {
     uint32_t width;
     uint32_t height;
-    uint8_t padding[16];
+    uint8_t padding[24];
 
     static const uint64_t code = 1;
     static void construct(Message& message, uint32_t width, uint32_t height)
@@ -57,7 +57,7 @@ struct BufferCommit {
 static_assert(sizeof(BufferCommit) == Message::dataSize, "BufferCommit is of correct size");
 
 struct FrameComplete {
-    int8_t padding[24];
+    int8_t padding[32];
 
     static const uint64_t code = 2;
     static void construct(Message& message)

--- a/src/bcm-rpi/ipc-rpi.h
+++ b/src/bcm-rpi/ipc-rpi.h
@@ -39,7 +39,7 @@ struct TargetConstruction {
     uint32_t handle;
     uint32_t width;
     uint32_t height;
-    uint8_t padding[12];
+    uint8_t padding[20];
 
     static const uint64_t code = 1;
     static void construct(Message& message, uint32_t handle, uint32_t width, uint32_t height)
@@ -62,7 +62,7 @@ struct BufferCommit {
     uint32_t handle;
     uint32_t width;
     uint32_t height;
-    uint8_t padding[12];
+    uint8_t padding[20];
 
     static const uint64_t code = 2;
     static void construct(Message& message, uint32_t handle, uint32_t width, uint32_t height)
@@ -82,7 +82,7 @@ struct BufferCommit {
 static_assert(sizeof(BufferCommit) == Message::dataSize, "BufferCommit is of correct size");
 
 struct FrameComplete {
-    int8_t padding[24];
+    int8_t padding[32];
 
     static const uint64_t code = 3;
     static void construct(Message& message)

--- a/src/intelce/ipc-intelce.h
+++ b/src/intelce/ipc-intelce.h
@@ -38,7 +38,7 @@ namespace IntelCE {
 struct BufferCommit {
     uint32_t width;
     uint32_t height;
-    uint8_t padding[16];
+    uint8_t padding[24];
 
     static const uint64_t code = 1;
     static void construct(Message& message, uint32_t width, uint32_t height)
@@ -57,7 +57,7 @@ struct BufferCommit {
 static_assert(sizeof(BufferCommit) == Message::dataSize, "BufferCommit is of correct size");
 
 struct FrameComplete {
-    int8_t padding[24];
+    int8_t padding[32];
 
     static const uint64_t code = 2;
     static void construct(Message& message)

--- a/src/realtek-wl-egl/ipc-waylandegl.h
+++ b/src/realtek-wl-egl/ipc-waylandegl.h
@@ -37,7 +37,7 @@ namespace IPC {
 namespace WaylandEGL {
 
 struct BufferCommit {
-    uint8_t padding[24];
+    uint8_t padding[32];
 
     static const uint64_t code = 1;
     static void construct(Message& message)
@@ -52,7 +52,7 @@ struct BufferCommit {
 static_assert(sizeof(BufferCommit) == Message::dataSize, "BufferCommit is of correct size");
 
 struct FrameComplete {
-    int8_t padding[24];
+    int8_t padding[32];
 
     static const uint64_t code = 2;
     static void construct(Message& message)

--- a/src/util/ipc.h
+++ b/src/util/ipc.h
@@ -35,8 +35,8 @@
 namespace IPC {
 
 struct Message {
-    static const size_t size = 32;
-    static const size_t dataSize = 24;
+    static const size_t size = 40;
+    static const size_t dataSize = 32;
 
     uint64_t messageCode { 0 };
     uint8_t messageData[dataSize] { 0, };

--- a/src/viv-imx6/ipc-viv-imx6.h
+++ b/src/viv-imx6/ipc-viv-imx6.h
@@ -39,7 +39,7 @@ namespace VIVimx6 {
 struct BufferCommit {
     uint32_t width;
     uint32_t height;
-    uint8_t padding[16];
+    uint8_t padding[24];
 
     static const uint64_t code = 1;
     static void construct(Message& message, uint32_t width, uint32_t height)
@@ -58,7 +58,7 @@ struct BufferCommit {
 static_assert(sizeof(BufferCommit) == Message::dataSize, "BufferCommit is of correct size");
 
 struct FrameComplete {
-    int8_t padding[24];
+    int8_t padding[32];
 
     static const uint64_t code = 2;
     static void construct(Message& message)

--- a/src/wayland-egl/ipc-waylandegl.h
+++ b/src/wayland-egl/ipc-waylandegl.h
@@ -37,7 +37,7 @@ namespace IPC {
 namespace WaylandEGL {
 
 struct BufferCommit {
-    uint8_t padding[24];
+    uint8_t padding[32];
 
     static const uint64_t code = 1;
     static void construct(Message& message)
@@ -52,7 +52,7 @@ struct BufferCommit {
 static_assert(sizeof(BufferCommit) == Message::dataSize, "BufferCommit is of correct size");
 
 struct FrameComplete {
-    int8_t padding[24];
+    int8_t padding[32];
 
     static const uint64_t code = 2;
     static void construct(Message& message)

--- a/src/wayland/display.cpp
+++ b/src/wayland/display.cpp
@@ -648,6 +648,7 @@ void EventDispatcher::sendEvent( wpe_input_axis_event& event )
         m_ipc->sendMessage(IPC::Message::data(message), IPC::Message::size);
     }
 }
+static_assert(sizeof(wpe_input_axis_event) <= IPC::Message::dataSize, "Message can contain a wpe_input_axis_event");
 
 void EventDispatcher::sendEvent( wpe_input_pointer_event& event )
 {
@@ -659,6 +660,7 @@ void EventDispatcher::sendEvent( wpe_input_pointer_event& event )
         m_ipc->sendMessage(IPC::Message::data(message), IPC::Message::size);
     }
 }
+static_assert(sizeof(wpe_input_pointer_event) <= IPC::Message::dataSize, "Message can contain a wpe_input_pointer_event");
 
 void EventDispatcher::sendEvent( wpe_input_touch_event& event )
 {
@@ -670,6 +672,7 @@ void EventDispatcher::sendEvent( wpe_input_touch_event& event )
         m_ipc->sendMessage(IPC::Message::data(message), IPC::Message::size);
     }
 }
+static_assert(sizeof(wpe_input_touch_event) <= IPC::Message::dataSize, "Message can contain a wpe_input_touch_event");
 
 void EventDispatcher::sendEvent( wpe_input_keyboard_event& event )
 {
@@ -681,6 +684,7 @@ void EventDispatcher::sendEvent( wpe_input_keyboard_event& event )
         m_ipc->sendMessage(IPC::Message::data(message), IPC::Message::size);
     }
 }
+static_assert(sizeof(wpe_input_keyboard_event) <= IPC::Message::dataSize, "Message can contain a wpe_input_keyboard_event");
 
 void EventDispatcher::sendEvent( wpe_input_touch_event_raw& event )
 {
@@ -692,6 +696,7 @@ void EventDispatcher::sendEvent( wpe_input_touch_event_raw& event )
         m_ipc->sendMessage(IPC::Message::data(message), IPC::Message::size);
     }
 }
+static_assert(sizeof(wpe_input_touch_event_raw) <= IPC::Message::dataSize, "Message can contain a wpe_input_touch_event_raw");
 
 void EventDispatcher::setIPC( IPC::Client& ipcClient )
 {

--- a/src/wpeframework/display.cpp
+++ b/src/wpeframework/display.cpp
@@ -211,6 +211,7 @@ Display::~Display()
     std::memcpy(message.messageData, &event, sizeof(event));
     m_ipc.sendMessage(IPC::Message::data(message), IPC::Message::size);
 }
+static_assert(sizeof(wpe_input_keyboard_event) <= IPC::Message::dataSize, "Message can contain a wpe_input_keyboard_event");
 
 /* virtual */ void Display::Key(const bool pressed, uint32_t keycode, uint32_t hardware_keycode, uint32_t modifiers, uint32_t time)
 {
@@ -231,6 +232,7 @@ void Display::SendEvent(wpe_input_axis_event& event)
     std::memcpy(message.messageData, &event, sizeof(event));
     m_ipc.sendMessage(IPC::Message::data(message), IPC::Message::size);
 }
+static_assert(sizeof(wpe_input_axis_event) <= IPC::Message::dataSize, "Message can contain a wpe_input_axis_event");
 
 void Display::SendEvent(wpe_input_pointer_event& event)
 {
@@ -239,6 +241,7 @@ void Display::SendEvent(wpe_input_pointer_event& event)
     std::memcpy(message.messageData, &event, sizeof(event));
     m_ipc.sendMessage(IPC::Message::data(message), IPC::Message::size);
 }
+static_assert(sizeof(wpe_input_pointer_event) <= IPC::Message::dataSize, "Message can contain a wpe_input_pointer_event");
 
 void Display::SendEvent(wpe_input_touch_event& event)
 {
@@ -247,6 +250,7 @@ void Display::SendEvent(wpe_input_touch_event& event)
     std::memcpy(message.messageData, &event, sizeof(event));
     m_ipc.sendMessage(IPC::Message::data(message), IPC::Message::size);
 }
+static_assert(sizeof(wpe_input_touch_event) <= IPC::Message::dataSize, "Message can contain a wpe_input_touch_event");
 
 /* If we have pointer and or touch support in the abstraction layer, link it through like here 
 static const struct wl_pointer_listener g_pointerListener = {

--- a/src/wpeframework/ipc-buffer.h
+++ b/src/wpeframework/ipc-buffer.h
@@ -35,7 +35,7 @@
 namespace IPC {
 
 struct BufferCommit {
-    uint8_t padding[24];
+    uint8_t padding[32];
 
     static const uint64_t code = 1;
     static void construct(Message& message)
@@ -50,7 +50,7 @@ struct BufferCommit {
 static_assert(sizeof(BufferCommit) == Message::dataSize, "BufferCommit is of correct size");
 
 struct FrameComplete {
-    int8_t padding[24];
+    int8_t padding[32];
 
     static const uint64_t code = 2;
     static void construct(Message& message)


### PR DESCRIPTION
IPC::Message::messageData is too small for wpe_input_axis_event, wpe_input_pointer_event and
wpe_input_touch_event.
GCC only outputs a warning when building with -D_FORTIFY_SOURCE=2, now with the static
asserts it would properly fail if the issue happens again.