### PR TITLE
include <array> for std::array

### DIFF
--- a/src/input/Libinput/LibinputServer.h
+++ b/src/input/Libinput/LibinputServer.h
@@ -30,6 +30,7 @@
 
 #include "KeyboardEventRepeating.h"
 #include <glib.h>
+#include <array>
 #include <memory>
 #include <wpe/wpe.h>
 #ifndef KEY_INPUT_HANDLING_VIRTUAL


### PR DESCRIPTION
libcxx/clang does nor pardon such mistakes
LibinputServer.h:81:54: error: implicit instantiation of undefined template 'std::__1::array<wpe_input_touch_event_raw, 10>'

Signed-off-by: Khem Raj <raj.khem@gmail.com>