### PR TITLE
Fix memory corruption (too small IPC::Message::messageData)

### DIFF
--- a/src/util/ipc.h
+++ b/src/util/ipc.h
@@ -35,8 +35,8 @@
 namespace IPC {
 
 struct Message {
-    static const size_t size = 32;
-    static const size_t dataSize = 24;
+    static constexpr size_t size = 40;
+    static constexpr size_t dataSize = 32;
 
     uint64_t messageCode { 0 };
     uint8_t messageData[dataSize] { 0, };

--- a/src/wayland-egl/ipc-waylandegl.h
+++ b/src/wayland-egl/ipc-waylandegl.h
@@ -37,7 +37,7 @@ namespace IPC {
 namespace WaylandEGL {
 
 struct BufferCommit {
-    uint8_t padding[24];
+    uint8_t padding[sizeof(Message::messageData)];
 
     static const uint64_t code = 1;
     static void construct(Message& message)
@@ -52,7 +52,7 @@ struct BufferCommit {
 static_assert(sizeof(BufferCommit) == Message::dataSize, "BufferCommit is of correct size");
 
 struct FrameComplete {
-    int8_t padding[24];
+    int8_t padding[sizeof(Message::messageData)];
 
     static const uint64_t code = 2;
     static void construct(Message& message)

--- a/src/wayland/display.cpp
+++ b/src/wayland/display.cpp
@@ -644,6 +644,7 @@ void EventDispatcher::sendEvent( wpe_input_axis_event& event )
     {
         IPC::Message message;
         message.messageCode = MsgType::AXIS;
+        static_assert(sizeof(event) <= sizeof(message.messageData), "Message::messageData is of correct size");
         memcpy( message.messageData, &event, sizeof(event) );
         m_ipc->sendMessage(IPC::Message::data(message), IPC::Message::size);
     }


### PR DESCRIPTION
Copying wpe_input_axis_event to IPC::Message::messageData
in the code like:

    memcpy( message.messageData, &event, sizeof(event) );

causes memory corruption as the size of messageData is 24
while the size of wpe_input_axis_event is 28 bytes.

Dump of relevant offsets:

(gdb) ptype /o IPC::Message
/* offset    |  size */  type = struct IPC::Message {
                           static const size_t size;
                           static const size_t dataSize;
/*    0      |     8 */    uint64_t messageCode;
/*    8      |    24 */    uint8_t messageData[24];

                           /* total size (bytes):   32 */
                         }
(gdb) ptype /o wpe_input_axis_event
/* offset    |  size */  type = struct wpe_input_axis_event {
/*    0      |     4 */    enum wpe_input_axis_event_type type;
/*    4      |     4 */    uint32_t time;
/*    8      |     4 */    int x;
/*   12      |     4 */    int y;
/*   16      |     4 */    uint32_t axis;
/*   20      |     4 */    int32_t value;
/*   24      |     4 */    uint32_t modifiers;

                           /* total size (bytes):   28 */
                         }

Fix increases the size of messageData appropriately and adds a
static_assert() to make sure the program will not compile rather
than trying to corrupt the memory.