### PR TITLE
[wayland-egl] Avoid leaking wl_region object

### DIFF
--- a/src/wayland-egl/renderer-backend.cpp
+++ b/src/wayland-egl/renderer-backend.cpp
@@ -120,12 +120,13 @@ void EGLTarget::initialize(Backend& backend, uint32_t width, uint32_t height)
             wl_shell_surface_set_fullscreen(m_shellSurface, WL_SHELL_SURFACE_FULLSCREEN_METHOD_DEFAULT, 0, NULL);
         }
     }
-    struct wl_region *region;
-    region = wl_compositor_create_region(m_backend->display.interfaces().compositor);
+
+    struct wl_region *region = wl_compositor_create_region(m_backend->display.interfaces().compositor);
     wl_region_add(region, 0, 0,
                    width,
                    height);
     wl_surface_set_opaque_region(m_surface, region);
+    wl_region_destroy(region);
 
     m_window = wl_egl_window_create(m_surface, width, height);
 }


### PR DESCRIPTION
Destroy the `wl_region` object used to configure the opaque region of the surface after it has been used by `wl_surface_set_opaque_region()`, which makes a copy of the region.