### PR TITLE
Added Thunder to WPE Key Mapping module

### DIFF
--- a/src/input/KeyMapper/KeyMapper.h
+++ b/src/input/KeyMapper/KeyMapper.h
@@ -1,0 +1,209 @@
+#pragma once
+
+#include <linux/input.h>
+#include <wpe/wpe.h>
+
+namespace WPE {
+
+class KeyMapper {
+public:
+    KeyMapper(const KeyMapper&) = delete;
+    KeyMapper& operator=(const KeyMapper&) = delete;
+    KeyMapper()
+    {
+    }
+    ~KeyMapper() = default;
+public:
+    static uint32_t KeyCodeToWpeKey(uint16_t code)
+    {
+        uint32_t keyCode = 0;
+        switch (code) {
+        case KEY_BACKSPACE:
+            keyCode = WPE_KEY_BackSpace;
+            break;
+        case KEY_DELETE:
+            keyCode = WPE_KEY_Delete;
+            break;
+        case KEY_TAB:
+            keyCode = WPE_KEY_Tab;
+            break;
+        case KEY_LINEFEED:
+        case KEY_ENTER:
+        case KEY_KPENTER:
+            keyCode = WPE_KEY_Linefeed;
+            break;
+        case KEY_CLEAR:
+            keyCode = WPE_KEY_Clear;
+            break;
+        case KEY_SPACE:
+            keyCode = WPE_KEY_space;
+            break;
+        case KEY_HOME:
+            keyCode = WPE_KEY_Home;
+            break;
+        case KEY_END:
+            keyCode = WPE_KEY_End;
+            break;
+        case KEY_PAGEUP:
+            keyCode = WPE_KEY_Prior;
+            break;
+        case KEY_PAGEDOWN:
+            keyCode = WPE_KEY_Next;
+            break;
+        case KEY_LEFT:
+            keyCode = WPE_KEY_Left;
+            break;
+        case KEY_RIGHT:
+            keyCode = WPE_KEY_Right;
+            break;
+        case KEY_DOWN:
+            keyCode = WPE_KEY_Down;
+            break;
+        case KEY_UP:
+            keyCode = WPE_KEY_Up;
+            break;
+        case KEY_ESC:
+            keyCode = WPE_KEY_Escape;
+            break;
+        case KEY_A:
+            keyCode = WPE_KEY_a;
+            break;
+        case KEY_B:
+            keyCode = WPE_KEY_b;
+            break;
+        case KEY_C:
+            keyCode = WPE_KEY_c;
+            break;
+        case KEY_D:
+            keyCode = WPE_KEY_d;
+            break;
+        case KEY_E:
+            keyCode = WPE_KEY_e;
+            break;
+        case KEY_F:
+            keyCode = WPE_KEY_f;
+            break;
+        case KEY_G:
+            keyCode = WPE_KEY_g;
+            break;
+        case KEY_H:
+            keyCode = WPE_KEY_h;
+            break;
+        case KEY_I:
+            keyCode = WPE_KEY_i;
+            break;
+        case KEY_J:
+            keyCode = WPE_KEY_j;
+            break;
+        case KEY_K:
+            keyCode = WPE_KEY_k;
+            break;
+        case KEY_L:
+            keyCode = WPE_KEY_l;
+            break;
+        case KEY_M:
+            keyCode = WPE_KEY_m;
+            break;
+        case KEY_N:
+            keyCode = WPE_KEY_n;
+            break;
+        case KEY_O:
+            keyCode = WPE_KEY_o;
+            break;
+        case KEY_P:
+            keyCode = WPE_KEY_p;
+            break;
+        case KEY_Q:
+            keyCode = WPE_KEY_q;
+            break;
+        case KEY_R:
+            keyCode = WPE_KEY_r;
+            break;
+        case KEY_S:
+            keyCode = WPE_KEY_s;
+            break;
+        case KEY_T:
+            keyCode = WPE_KEY_t;
+            break;
+        case KEY_U:
+            keyCode = WPE_KEY_u;
+            break;
+        case KEY_V:
+            keyCode = WPE_KEY_v;
+            break;
+        case KEY_W:
+            keyCode = WPE_KEY_w;
+            break;
+        case KEY_X:
+            keyCode = WPE_KEY_x;
+            break;
+        case KEY_Y:
+            keyCode = WPE_KEY_y;
+            break;
+        case KEY_Z:
+            keyCode = WPE_KEY_z;
+            break;
+
+        case KEY_0:
+            keyCode = WPE_KEY_0;
+            break;
+        case KEY_1:
+            keyCode = WPE_KEY_1;
+            break;
+        case KEY_2:
+            keyCode = WPE_KEY_2;
+            break;
+        case KEY_3:
+            keyCode = WPE_KEY_3;
+            break;
+        case KEY_4:
+            keyCode = WPE_KEY_4;
+            break;
+        case KEY_5:
+            keyCode = WPE_KEY_5;
+            break;
+        case KEY_6:
+            keyCode = WPE_KEY_6;
+            break;
+        case KEY_7:
+            keyCode = WPE_KEY_7;
+            break;
+        case KEY_8:
+            keyCode = WPE_KEY_8;
+            break;
+        case KEY_9:
+            keyCode = WPE_KEY_9;
+            break;
+
+        case KEY_MINUS:
+            keyCode = WPE_KEY_minus;
+            break;
+        case KEY_EQUAL:
+            keyCode = WPE_KEY_equal;
+            break;
+        case KEY_SEMICOLON:
+            keyCode = WPE_KEY_semicolon;
+            break;
+        case KEY_APOSTROPHE:
+            keyCode = WPE_KEY_apostrophe;
+            break;
+        case KEY_COMMA:
+            keyCode = WPE_KEY_comma;
+            break;
+        case KEY_DOT:
+            keyCode = WPE_KEY_period;
+            break;
+        case KEY_SLASH:
+            keyCode = WPE_KEY_slash;
+            break;
+        case KEY_BACKSLASH:
+            keyCode = WPE_KEY_backslash;
+            break;
+
+        default:
+            break;
+        }
+        return keyCode;
+    }
+};    
+}

--- a/src/input/KeyMapper/KeyMapper.h
+++ b/src/input/KeyMapper/KeyMapper.h
@@ -199,6 +199,29 @@ public:
         case KEY_BACKSLASH:
             keyCode = WPE_KEY_backslash;
             break;
+        case KEY_CAPSLOCK:
+            keyCode = WPE_KEY_Caps_Lock;
+            break;
+
+        case KEY_RED:
+            keyCode = WPE_KEY_Red;
+            break;
+        case KEY_GREEN:
+            keyCode = WPE_KEY_Green;
+            break;
+        case KEY_YELLOW:
+            keyCode = WPE_KEY_Yellow;
+            break;
+        case KEY_BLUE:
+            keyCode = WPE_KEY_Blue;
+            break;
+
+        case KEY_NUMERIC_POUND:
+            keyCode = WPE_KEY_sterling;
+            break;
+        case KEY_EURO:
+            keyCode = WPE_KEY_EuroSign;
+            break;
 
         default:
             break;

--- a/src/input/KeyMapper/KeyMapperWpe.h
+++ b/src/input/KeyMapper/KeyMapperWpe.h
@@ -9,10 +9,9 @@ class KeyMapper {
 public:
     KeyMapper(const KeyMapper&) = delete;
     KeyMapper& operator=(const KeyMapper&) = delete;
-    KeyMapper()
-    {
-    }
+    KeyMapper() = default;
     ~KeyMapper() = default;
+
 public:
     static uint32_t KeyCodeToWpeKey(uint16_t code)
     {

--- a/src/input/KeyMapper/KeyMapperWpe.h
+++ b/src/input/KeyMapper/KeyMapperWpe.h
@@ -30,7 +30,7 @@ public:
         case KEY_LINEFEED:
         case KEY_ENTER:
         case KEY_KPENTER:
-            keyCode = WPE_KEY_Linefeed;
+            keyCode = WPE_KEY_Return;
             break;
         case KEY_CLEAR:
             keyCode = WPE_KEY_Clear;

--- a/src/wpeframework/display.cpp
+++ b/src/wpeframework/display.cpp
@@ -25,6 +25,7 @@
  */
 
 #include "display.h"
+#include <KeyMapper/KeyMapper.h>
 #include <cstring>
 #include <chrono>
 
@@ -108,12 +109,9 @@ void KeyboardHandler::RepeatDelayTimeout() {
 }
 
 void KeyboardHandler::HandleKeyEvent(const uint32_t key, const IKeyboard::state action, const uint32_t time) {
-    uint32_t keysym = wpe_input_xkb_context_get_key_code(wpe_input_xkb_context_get_default(), key, action == IKeyboard::pressed);
-    if (!keysym)
-	return;
 
     // Send the event, it is complete..
-    _callback->Key(action == IKeyboard::pressed, keysym, key, _modifiers, time);
+    _callback->Key(action == IKeyboard::pressed, WPE::KeyMapper::KeyCodeToWpeKey(key), key, _modifiers, time);
 }
 
 /* virtual */ void KeyboardHandler::Direct(const uint32_t key, const Compositor::IDisplay::IKeyboard::state action)
@@ -122,38 +120,36 @@ void KeyboardHandler::HandleKeyEvent(const uint32_t key, const IKeyboard::state 
 }
 
 /* virtual */ void KeyboardHandler::KeyMap(const char information[], const uint16_t size) {
-    auto* xkb = wpe_input_xkb_context_get_default();
-    auto* keymap = xkb_keymap_new_from_string(wpe_input_xkb_context_get_context(xkb), information, XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS);
-    wpe_input_xkb_context_set_keymap(xkb, keymap);
-    xkb_keymap_unref(keymap);
 }
 
 /* virtual */ void KeyboardHandler::Key(const uint32_t key, const IKeyboard::state action, const uint32_t time) {
     // IDK.
-    uint32_t actual_key = key + 8;
-    HandleKeyEvent(actual_key, action, time);
-
-    auto* keymap = wpe_input_xkb_context_get_keymap(wpe_input_xkb_context_get_default());
+    HandleKeyEvent(key, action, time);
 
     if (_repeatInfo.rate != 0) {
-        if (action == IKeyboard::released && _repeatData.key == actual_key) {
+        if (action == IKeyboard::released && _repeatData.key == key) {
             if (_repeatData.eventSource)
                 g_source_remove(_repeatData.eventSource);
             _repeatData = { 0, 0, IKeyboard::released, 0 };
         }
-        else if (action == IKeyboard::pressed
-            && keymap && xkb_keymap_key_repeats(keymap, actual_key)) {
-
-            if (_repeatData.eventSource)
-                g_source_remove(_repeatData.eventSource);
-
-            _repeatData = { actual_key, time, action, g_timeout_add(_repeatInfo.delay, static_cast<GSourceFunc>(repeatDelayTimeout), this) };
+        else if (action == IKeyboard::pressed) {
+        // TODO: add code to handle repeat key
         }
     }
 }
 
 /* virtual */ void KeyboardHandler::Modifiers(uint32_t depressedMods, uint32_t latchedMods, uint32_t lockedMods, uint32_t group) {
-    _modifiers = wpe_input_xkb_context_get_modifiers(wpe_input_xkb_context_get_default(), depressedMods, latchedMods, lockedMods, group);
+      // Convert to SbKeyModifiers.
+  unsigned int modifiers = 0;
+
+  if (depressedMods & 1)
+    modifiers |= wpe_input_keyboard_modifier_shift;
+  if (depressedMods & 4)
+    modifiers |= wpe_input_keyboard_modifier_control;
+  if (depressedMods & 8)
+    modifiers |= wpe_input_keyboard_modifier_alt;
+
+  _modifiers = modifiers;
 }
 
 /* virtual */ void KeyboardHandler::Repeat(int32_t rate, int32_t delay) {
@@ -259,20 +255,8 @@ Display::~Display()
 }
 
 /* virtual */ void Display::Key (const uint32_t keycode, const Compositor::IDisplay::IKeyboard::state actions) {
-    uint32_t actual_key = keycode + 8;
-
-    auto* xkb = wpe_input_xkb_context_get_default();
-    uint32_t keysym = wpe_input_xkb_context_get_key_code(xkb, actual_key, !!actions);
-    if (!keysym)
-        return;
-    auto* xkbState = wpe_input_xkb_context_get_state(xkb);
-    xkb_state_update_key(xkbState, actual_key, !!actions ? XKB_KEY_DOWN : XKB_KEY_UP);
-    uint32_t modifiers = wpe_input_xkb_context_get_modifiers(xkb,
-        xkb_state_serialize_mods(xkbState, XKB_STATE_MODS_DEPRESSED),
-        xkb_state_serialize_mods(xkbState, XKB_STATE_MODS_LATCHED),
-        xkb_state_serialize_mods(xkbState, XKB_STATE_MODS_LOCKED),
-        xkb_state_serialize_layout(xkbState, XKB_STATE_LAYOUT_EFFECTIVE));
-    struct wpe_input_keyboard_event event{ TimeNow(), keysym, actual_key, !!actions, modifiers };
+    uint32_t modifiers = 0;
+    struct wpe_input_keyboard_event event{ TimeNow(), WPE::KeyMapper::KeyCodeToWpeKey(keycode), actual_key, !!actions, modifiers };
     IPC::Message message;
     message.messageCode = MsgType::KEYBOARD;
     std::memcpy(message.messageData, &event, sizeof(event));

--- a/src/wpeframework/display.cpp
+++ b/src/wpeframework/display.cpp
@@ -139,7 +139,6 @@ void KeyboardHandler::HandleKeyEvent(const uint32_t key, const IKeyboard::state 
 }
 
 /* virtual */ void KeyboardHandler::Modifiers(uint32_t depressedMods, uint32_t latchedMods, uint32_t lockedMods, uint32_t group) {
-      // Convert to SbKeyModifiers.
   unsigned int modifiers = 0;
 
   if (depressedMods & 1)
@@ -255,6 +254,7 @@ Display::~Display()
 }
 
 /* virtual */ void Display::Key (const uint32_t keycode, const Compositor::IDisplay::IKeyboard::state actions) {
+    uint32_t actual_key = keycode + 8;
     uint32_t modifiers = 0;
     struct wpe_input_keyboard_event event{ TimeNow(), WPE::KeyMapper::KeyCodeToWpeKey(keycode), actual_key, !!actions, modifiers };
     IPC::Message message;

--- a/src/wpeframework/display.cpp
+++ b/src/wpeframework/display.cpp
@@ -25,9 +25,9 @@
  */
 
 #include "display.h"
-#include <KeyMapper/KeyMapper.h>
 #include <cstring>
 #include <chrono>
+#include <KeyMapper/KeyMapperWpe.h>
 
 namespace WPEFramework {
 

--- a/src/wpeframework/display.h
+++ b/src/wpeframework/display.h
@@ -59,7 +59,9 @@ public:
     };
 
 public:
-    KeyboardHandler (IKeyHandler* callback) : _callback(callback) {
+    KeyboardHandler (IKeyHandler* callback)
+        : _callback(callback)
+        , _modifiers(0) {
     }
     virtual ~KeyboardHandler() {
     }


### PR DESCRIPTION
Currently In Thunder backend, the key conversion to WPE is handling using the XKB module. The KeyMapper will avoid the XKB calls and do the direct conversion from Thunder Key to WPE key.