### PR TITLE
wpeframework: add get_parent_surface api, bump libwpe, cmake wpebackend-rdk.pc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 project(WPEBackend-rdk)
 
+set(WPEBACKEND_RDK_API_VERSION 1.0)
+
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -fno-exceptions -fno-strict-aliasing")
@@ -146,3 +148,9 @@ add_custom_command(TARGET WPEBackend-rdk
         COMMAND ${CMAKE_COMMAND} -E create_symlink libWPEBackend-rdk.so ${CMAKE_BINARY_DIR}/libWPEBackend-default.so
         )
 install(FILES ${CMAKE_BINARY_DIR}/libWPEBackend-default.so DESTINATION "${CMAKE_INSTALL_PREFIX}/lib")
+
+configure_file(wpebackend-rdk.pc.in wpebackend-rdk-${WPEBACKEND_RDK_API_VERSION}.pc @ONLY)
+install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/wpebackend-rdk-${WPEBACKEND_RDK_API_VERSION}.pc"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,16 @@ endif ()
 
 if (USE_BACKEND_WPEFRAMEWORK)
     include(src/wpeframework/CMakeLists.txt)
+
+    set(WPEBACKEND_RDK_PUBLIC_HEADERS
+        src/wpeframework/compositorclient-get-surface.h
+    )
+
+    install(
+        FILES ${WPEBACKEND_RDK_PUBLIC_HEADERS}
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/wpe-rdk-${WPEBACKEND_RDK_API_VERSION}/wpe
+    )
+
 endif ()
 
 if (USE_BACKEND_WAYLAND_EGL)

--- a/cmake/FindWPE.cmake
+++ b/cmake/FindWPE.cmake
@@ -29,7 +29,7 @@
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 find_package(PkgConfig)
-pkg_check_modules(PC_WPE QUIET wpe-0.2)
+pkg_check_modules(PC_WPE QUIET wpe-1.0)
 
 find_path(WPE_INCLUDE_DIRS
     NAMES wpe/wpe.h
@@ -37,7 +37,7 @@ find_path(WPE_INCLUDE_DIRS
 )
 
 find_library(WPE_LIBRARIES
-    NAMES wpe-0.2
+    NAMES wpe-1.0
     HINTS ${PC_WPE_LIBDIR} ${PC_WPE_LIBRARY_DIRS}
 )
 

--- a/src/wpeframework/CMakeLists.txt
+++ b/src/wpeframework/CMakeLists.txt
@@ -33,6 +33,7 @@ list(APPEND WPE_PLATFORM_SOURCES
     src/wpeframework/renderer-backend.cpp
     src/wpeframework/view-backend.cpp
     src/wpeframework/display.cpp
+    src/wpeframework/compositorclient-get-surface.cpp
 )
 
 

--- a/src/wpeframework/compositorclient-get-surface.cpp
+++ b/src/wpeframework/compositorclient-get-surface.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2020 Linaro
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <wayland-egl.h>
+#include <wayland-egl-backend.h>
+#include "compositorclient-get-surface.h"
+#include "display.h"
+#include <wpe/wpe-egl.h>
+#include <compositor/Client.h>
+#include <cstring>
+
+namespace WPEFramework {
+
+extern "C" {
+
+__attribute__((visibility("default")))
+void* wpe_compositorclient_get_parent_surface(struct wpe_renderer_backend_egl* backend)
+{
+    Compositor::IDisplay::ISurface* surface;
+    void* nativesurface = nullptr;
+    EGLNativeWindowType nativewindow;
+
+    if (!backend)
+      return nativesurface;;
+
+    auto* base = reinterpret_cast<struct wpe_renderer_backend_egl_base*>(backend);
+    auto* display = reinterpret_cast<WPEFramework::Compositor::IDisplay*>(base->interface_data);
+
+    //get the ISurface from the IDisplay
+    if (display)
+        surface = display->SurfaceByName(Compositor::IDisplay::SuggestedName());
+
+    //get the native surface
+    if (surface) {
+	    nativewindow = surface->Native();
+#if defined WL_EGL_PLATFORM
+	    // On wayland EGLNativeWindowType is struct wl_egl_window * that contains the surface
+	    nativesurface  = nativewindow->surface;
+#endif
+    }
+
+    return nativesurface;
+}
+
+}
+
+}

--- a/src/wpeframework/compositorclient-get-surface.h
+++ b/src/wpeframework/compositorclient-get-surface.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2020 Linaro
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __compositorclient_get_surface_h__
+#define __compositorclient_get_surface_h__
+
+#include <stdint.h>
+#include <wpe/wpe.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct wpe_renderer_backend_egl;
+
+void* wpe_compositorclient_get_parent_surface(struct wpe_renderer_backend_egl*);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __compositorclient_get_surface_h__

--- a/src/wpeframework/renderer-backend.cpp
+++ b/src/wpeframework/renderer-backend.cpp
@@ -109,7 +109,7 @@ struct wpe_renderer_backend_egl_interface wpeframework_renderer_backend_egl_inte
     // create
     [](int input) -> void*
     {
-        return nullptr;
+        return WPEFramework::Compositor::IDisplay::Instance(WPEFramework::DisplayName());
     },
     // destroy
     [](void* data)

--- a/wpebackend-rdk.pc.in
+++ b/wpebackend-rdk.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+includedir=${prefix}/include
+libdir=${exec_prefix}/lib
+
+Name: wpebackend-rdk-@WPEBACKEND_FDO_API_VERSION@
+Description: The WPEBackend-rdk library
+Version: @PROJECT_VERSION@
+Requires: wpe-1.0
+Cflags: -I${includedir}/wpe-rdk-@WPEBACKEND_RDK_API_VERSION@
+Libs: -L${libdir} -lWPEBackend-fdo-@WPEBACKEND_RDK_API_VERSION@


### PR DESCRIPTION
This pull request does 3 things
- Updates wpebackend-rdk to have a dependency on newer libwpe library. Currently the libwpe dependency is very old.
- Adds CMake support to generate a wpebackend-rdk.pc file. That allows wpewebkit to easily include headers etc.
- Adds a new api wpe_compositorclient_get_parent_surface() and public header. This allows us to get the parent surface created by Thunder/wpeframework compositor client code. Support for GetNativeSurface() is added to Thunder via a separate pull request.

With these changes and corresponding changes in Thunder and wpewebkit it is possible to have waylandsink as the webkit hole punch video sink functioning nicely. The following video demonstrates this which shows Widevine EME playback using OP-TEE, using Weston compositor, Thunder/wpeframework and OpenCDM, plus webkit using waylandsink as the video sink. https://photos.app.goo.gl/DEKhcYmWfxRsFDxw7