### PR TITLE
Handling essOutputMode events with different dimension

### DIFF
--- a/src/essos/renderer-backend.cpp
+++ b/src/essos/renderer-backend.cpp
@@ -311,7 +311,8 @@ void EGLTarget::initialize(Backend& backend, uint32_t width, uint32_t height)
     }
     else {
         // Request page resize if needed
-        onDisplaySize(targetWidth, targetHeight);
+        if ( pageWidth != targetWidth && pageHeight != targetHeight )
+            onDisplaySize(targetWidth, targetHeight);
     }
 
     if ( error ) {
@@ -592,8 +593,6 @@ void EGLTarget::onTouchMoution(int id, int x, int y)
 
 void EGLTarget::onDisplaySize(int width, int height)
 {
-    if (pageWidth == width && pageHeight == height)
-        return;
     DEBUG_LOG("display size=%dx%d, page size=%dx%d", width, height, pageWidth, pageHeight);
     IPC::Message message;
     IPC::Essos::DisplaySize::construct(message, width, height);


### PR DESCRIPTION
1) When successive essOutputMode events are received before the first event is handled by UIProcess, the events are neglected
2) Removing the dimension check won't have any impact as ESSOS already checks the current & new dimensions