### PR TITLE
Fix wayland event loop integration

### DIFF
--- a/src/wayland/display.cpp
+++ b/src/wayland/display.cpp
@@ -51,64 +51,76 @@ public:
     GSource source;
     GPollFD pfd;
     struct wl_display* display;
+    bool isReading;
 };
 
 GSourceFuncs EventSource::sourceFuncs = {
     // prepare
     [](GSource* base, gint* timeout) -> gboolean
     {
-        auto* source = reinterpret_cast<EventSource*>(base);
-        struct wl_display* display = source->display;
+        auto& source = *reinterpret_cast<EventSource*>(base);
 
         *timeout = -1;
 
-        while (wl_display_prepare_read(display) != 0) {
-            if (wl_display_dispatch_pending(display) < 0) {
-                fprintf(stderr, "Wayland::Display: error in wayland prepare\n");
-                return FALSE;
-            }
-        }
-        wl_display_flush(display);
+        if (source.isReading)
+            return FALSE;
 
+        // If there are pending dispatches we return TRUE to proceed to dispatching ASAP.
+        if (wl_display_prepare_read(source.display) != 0)
+            return TRUE;
+
+        source.isReading = true;
+
+        wl_display_flush(source.display);
         return FALSE;
     },
     // check
     [](GSource* base) -> gboolean
     {
-        auto* source = reinterpret_cast<EventSource*>(base);
-        struct wl_display* display = source->display;
+        auto& source = *reinterpret_cast<EventSource*>(base);
 
-        if (source->pfd.revents & G_IO_IN) {
-            if (wl_display_read_events(display) < 0) {
-                fprintf(stderr, "Wayland::Display: error in wayland read\n");
-                return FALSE;
-            }
-            return TRUE;
-        } else {
-            wl_display_cancel_read(display);
-            return FALSE;
+        // Only perform the read if input was made available during polling.
+        // Error during read is noted and will be handled in the following
+        // dispatch callback. If no input is available, the read is canceled.
+        if (source.isReading) {
+            source.isReading = false;
+
+            if (source.pfd.revents & G_IO_IN) {
+                if (wl_display_read_events(source.display) == 0)
+                    return TRUE;
+            } else
+                wl_display_cancel_read(source.display);
         }
+
+        return source.pfd.revents;
     },
     // dispatch
     [](GSource* base, GSourceFunc, gpointer) -> gboolean
     {
-        auto* source = reinterpret_cast<EventSource*>(base);
-        struct wl_display* display = source->display;
+        auto& source = *reinterpret_cast<EventSource*>(base);
 
-        if (source->pfd.revents & G_IO_IN) {
-            if (wl_display_dispatch_pending(display) < 0) {
-                fprintf(stderr, "Wayland::Display: error in wayland dispatch\n");
-                return G_SOURCE_REMOVE;
-            }
-        }
-
-        if (source->pfd.revents & (G_IO_ERR | G_IO_HUP))
+        // Remove the source if any error was registered.
+        if (source.pfd.revents & (G_IO_ERR | G_IO_HUP))
             return G_SOURCE_REMOVE;
 
-        source->pfd.revents = 0;
+        // Dispatch any pending events. The source is removed in case of
+        // an error occurring during this step.
+        if (wl_display_dispatch_pending(source.display) < 0)
+            return G_SOURCE_REMOVE;
+
+        source.pfd.revents = 0;
         return G_SOURCE_CONTINUE;
     },
-    nullptr, // finalize
+    // finalize
+    [](GSource* base)
+    {
+        auto& source = *reinterpret_cast<EventSource*>(base);
+
+        if (source.isReading) {
+            wl_display_cancel_read(source.display);
+            source.isReading = false;
+        }
+    },
     nullptr, // closure_callback
     nullptr, // closure_marshall
 };
@@ -546,6 +558,7 @@ Display::Display()
     m_eventSource = g_source_new(&EventSource::sourceFuncs, sizeof(EventSource));
     auto* source = reinterpret_cast<EventSource*>(m_eventSource);
     source->display = m_display;
+    source->isReading = false;
 
     source->pfd.fd = wl_display_get_fd(m_display);
     source->pfd.events = G_IO_IN | G_IO_ERR | G_IO_HUP;

--- a/src/westeros/renderer-backend.cpp
+++ b/src/westeros/renderer-backend.cpp
@@ -117,64 +117,76 @@ public:
     GSource source;
     GPollFD pfd;
     struct wl_display* display;
+    bool isReading;
 };
 
 GSourceFuncs EventSource::sourceFuncs = {
     // prepare
     [](GSource* base, gint* timeout) -> gboolean
     {
-        auto* source = reinterpret_cast<EventSource*>(base);
-        struct wl_display* display = source->display;
+        auto& source = *reinterpret_cast<EventSource*>(base);
 
         *timeout = -1;
 
-        while (wl_display_prepare_read(display) != 0) {
-            if (wl_display_dispatch_pending(display) < 0) {
-                DEBUG_PRINT("Wayland::Display: error in wayland prepare\n");
-                return FALSE;
-            }
-        }
-        wl_display_flush(display);
+        if (source.isReading)
+            return FALSE;
 
+        // If there are pending dispatches we return TRUE to proceed to dispatching ASAP.
+        if (wl_display_prepare_read(source.display) != 0)
+            return TRUE;
+
+        source.isReading = true;
+
+        wl_display_flush(source.display);
         return FALSE;
     },
     // check
     [](GSource* base) -> gboolean
     {
-        auto* source = reinterpret_cast<EventSource*>(base);
-        struct wl_display* display = source->display;
+        auto& source = *reinterpret_cast<EventSource*>(base);
 
-        if (source->pfd.revents & G_IO_IN) {
-            if (wl_display_read_events(display) < 0) {
-                DEBUG_PRINT("Wayland::Display: error in wayland read\n");
-                return FALSE;
-            }
-            return TRUE;
-        } else {
-            wl_display_cancel_read(display);
-            return FALSE;
+        // Only perform the read if input was made available during polling.
+        // Error during read is noted and will be handled in the following
+        // dispatch callback. If no input is available, the read is canceled.
+        if (source.isReading) {
+            source.isReading = false;
+
+            if (source.pfd.revents & G_IO_IN) {
+                if (wl_display_read_events(source.display) == 0)
+                    return TRUE;
+            } else
+                wl_display_cancel_read(source.display);
         }
+
+        return source.pfd.revents;
     },
     // dispatch
     [](GSource* base, GSourceFunc, gpointer) -> gboolean
     {
-        auto* source = reinterpret_cast<EventSource*>(base);
-        struct wl_display* display = source->display;
+        auto& source = *reinterpret_cast<EventSource*>(base);
 
-        if (source->pfd.revents & G_IO_IN) {
-            if (wl_display_dispatch_pending(display) < 0) {
-                DEBUG_PRINT("Wayland::Display: error in wayland dispatch\n");
-                return G_SOURCE_REMOVE;
-            }
-        }
-
-        if (source->pfd.revents & (G_IO_ERR | G_IO_HUP))
+        // Remove the source if any error was registered.
+        if (source.pfd.revents & (G_IO_ERR | G_IO_HUP))
             return G_SOURCE_REMOVE;
 
-        source->pfd.revents = 0;
+        // Dispatch any pending events. The source is removed in case of
+        // an error occurring during this step.
+        if (wl_display_dispatch_pending(source.display) < 0)
+            return G_SOURCE_REMOVE;
+
+        source.pfd.revents = 0;
         return G_SOURCE_CONTINUE;
     },
-    nullptr, // finalize
+    // finalize
+    [](GSource* base)
+    {
+        auto& source = *reinterpret_cast<EventSource*>(base);
+
+        if (source.isReading) {
+            wl_display_cancel_read(source.display);
+            source.isReading = false;
+        }
+    },
     nullptr, // closure_callback
     nullptr, // closure_marshall
 };
@@ -240,6 +252,7 @@ void Backend::initialize()
     m_eventSource = g_source_new(&EventSource::sourceFuncs, sizeof(EventSource));
     auto& source = *reinterpret_cast<EventSource*>(m_eventSource);
     source.display = m_display;
+    source.isReading = false;
 
     source.pfd.fd = wl_display_get_fd(m_display);
     source.pfd.events = G_IO_IN | G_IO_ERR | G_IO_HUP;


### PR DESCRIPTION
Synchronize the Wayland event loop with WPEBackend-fdo (but without a wl_event_queue).

Now the events which are already pending in "check" are dispatched in "dispatch" instead of
synchronously.
This allows glib to handle priorities, which should be fairer.

This fixes at least :
 - error handling :
  "check" failed repeatedly with "Wayland::Display: error in wayland read", but "dispatch"
  was not called so the source was not removed.

 - deadlock when g_main_context_check doesn't check our source :
  It happens either when the set of file descriptor changes, or when an higher priority
  source is ready.
  "prepare" was called twice without "check", then wl_display_read_events blocked forever.