### PR TITLE
wayland: destroy GSource to avoid use-after-free in destruction

### DIFF
--- a/src/wayland/display.cpp
+++ b/src/wayland/display.cpp
@@ -571,8 +571,10 @@ Display::Display()
 
 Display::~Display()
 {
-    if (m_eventSource)
+    if (m_eventSource) {
+        g_source_destroy(m_eventSource);
         g_source_unref(m_eventSource);
+    }
     m_eventSource = nullptr;
 
     if (m_interfaces.compositor)


### PR DESCRIPTION
When the display is destroyed, also properly destroy the event source
before unreffing it, otherwise it could keep running callbacks with
invalid source pointers.