### PR TITLE
[ONEM-24177] - stop key repeat on focus loss

### DIFF
--- a/src/wayland/display.cpp
+++ b/src/wayland/display.cpp
@@ -336,6 +336,11 @@ static const struct wl_keyboard_listener g_keyboardListener = {
         auto it = seatData.inputClients.find(surface);
         if (it != seatData.inputClients.end() && seatData.keyboard.target.first == it->first)
             seatData.keyboard.target = { nullptr, nullptr };
+
+        if (seatData.repeatData.key && seatData.repeatData.eventSource) {
+            g_source_remove(seatData.repeatData.eventSource);
+            seatData.repeatData = { 0, 0, 0, 0 };
+        }
     },
     // key
     [](void* data, struct wl_keyboard*, uint32_t serial, uint32_t time, uint32_t key, uint32_t state)


### PR DESCRIPTION
When WPE moved to the background a RELEASE/UP key event won't be got,
it causes starting the repeater of key events mechanism and infinite key repeat.
To fix it, the key events repeater mechanism has to be reset when moved
to the background.