### PR TITLE
Add process exit call when terminated (onTerminated event)

### DIFF
--- a/src/essos/renderer-backend.cpp
+++ b/src/essos/renderer-backend.cpp
@@ -603,6 +603,12 @@ void EGLTarget::onTerminated()
 {
     WARN_LOG("Terminated. Essos ctx = %p", essosCtx);
     stop();
+
+    g_timeout_add_seconds(1, [](gpointer) 
+        WARN_LOG("Exit");
+       _exit(1);
+       return G_SOURCE_REMOVE;
+       }, nullptr);
 }
 
 EGLNativeWindowType EGLTarget::getNativeWindow() const


### PR DESCRIPTION
When the compositor dies, this allows cleanup/termination of the process
avoiding it to remain stale if not cleaned by other means