### PR TITLE
Initialize class members

### DIFF
--- a/src/input/Libinput/LibinputServer.h
+++ b/src/input/Libinput/LibinputServer.h
@@ -70,7 +70,7 @@ private:
     // Input::KeyboardEventRepeating::Client
     void dispatchKeyboardEvent(uint32_t eventTime, uint32_t eventKey) override;
 
-    Client* m_client;
+    Client* m_client = nullptr;
     std::unique_ptr<Input::KeyboardEventRepeating> m_keyboardEventRepeating;
 
     bool m_handlePointerEvents { false };
@@ -78,7 +78,7 @@ private:
     std::pair<uint32_t, uint32_t> m_pointerBounds;
 
     bool m_handleTouchEvents { false };
-    std::array<struct wpe_input_touch_event_raw, 10> m_touchEvents;
+    std::array<struct wpe_input_touch_event_raw, 10> m_touchEvents{};
 
 #ifdef KEY_INPUT_HANDLING_VIRTUAL
 public:
@@ -91,7 +91,7 @@ private:
     void handleTouchEvent(struct libinput_event *event, enum wpe_input_touch_event_type type);
 
     struct udev* m_udev;
-    struct libinput* m_libinput;
+    struct libinput* m_libinput = nullptr;
 
     class EventSource {
     public:

--- a/src/wayland/display.h
+++ b/src/wayland/display.h
@@ -130,7 +130,7 @@ public:
             uint32_t eventSource;
         } repeatData { 0, 0, 0, 0 };
 
-        uint32_t serial;
+        uint32_t serial = 0;
     };
 
     void registerInputClient(struct wl_surface*, struct wpe_view_backend*);


### PR DESCRIPTION
This commit initializes class members to prevent reading from
uninitialized memory.
Problem detected by static code analyser.