### PR TITLE
[Essos] refresh target size before trying to resize the page

### DIFF
--- a/src/essos/renderer-backend.cpp
+++ b/src/essos/renderer-backend.cpp
@@ -310,6 +310,10 @@ void EGLTarget::initialize(Backend& backend, uint32_t width, uint32_t height)
         error = true;
     }
     else {
+        // Output geometry might have changed in EssContextStart, refresh target size.
+        if ( !EssContextGetUseDirect(essosCtx) )
+            EssContextGetDisplaySize(essosCtx, &targetWidth, &targetHeight );
+
         // Request page resize if needed
         if ( pageWidth != targetWidth && pageHeight != targetHeight )
             onDisplaySize(targetWidth, targetHeight);


### PR DESCRIPTION
When running in Wayland mode, display resize event could be handled in
EssContextStart() (that is calling EssContextRunEventLoopOnce
internally). Which could lead to incorrect page resize reported to Webkit.