### PR TITLE
Make FindLibudev.cmake more robust on cross-build environments.

### DIFF
--- a/cmake/FindLibudev.cmake
+++ b/cmake/FindLibudev.cmake
@@ -35,11 +35,26 @@ elseif(Libudev_FIND_REQUIRED)
 endif()
 
 find_package(PkgConfig)
-pkg_check_modules(LIBUDEV ${_LIBUDEV_MODE} libudev)
+pkg_check_modules(PC_LIBUDEV ${_LIBUDEV_MODE} libudev)
+
+find_path(LIBUDEV_INCLUDE_DIRS
+    NAMES libudev.h
+    HINTS ${PC_LIBUDEV_INCLUDEDIR} ${PC_LIBUDEV_INCLUDE_DIRS}
+)
+
+find_library(LIBUDEV_LIBRARIES
+    NAMES udev
+    HINTS ${PC_LIBUDEV_LIBDIR} ${PC_LIBUDEV_LIBRARY_DIRS}
+)
+
+mark_as_advanced(LIBUDEV_INCLUDE_DIRS LIBUDEV_LIBRARIES)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Libudev DEFAULT_MSG LIBUDEV_FOUND LIBUDEV_INCLUDE_DIRS LIBUDEV_LIBRARIES)
-mark_as_advanced(LIBUDEV_INCLUDE_DIRS LIBUDEV_LIBRARIES)
+
+find_package_handle_standard_args(Libudev
+    REQUIRED_VARS LIBUDEV_INCLUDE_DIRS LIBUDEV_LIBRARIES
+    FOUND_VAR LIBUDEV_FOUND
+    VERSION_VAR PC_LIBUDEV_VERSION)
 
 if(Libudev_FOUND AND NOT TARGET Libudev::Libudev)
     add_library(Libudev::Libudev UNKNOWN IMPORTED)


### PR DESCRIPTION
The previous version was failing to properly set the variable `LIBUDEV_INCLUDE_DIRS` causing the build to fail (with Yocto langdale)

This was the failure:

```
| -- The C compiler identification is GNU 12.2.0
| -- The CXX compiler identification is GNU 12.2.0
| -- Detecting C compiler ABI info
| -- Detecting C compiler ABI info - done
| -- Check for working C compiler: /home/clopez/webkit/webkit/WebKitBuild/CrossToolChains/rpi3-dispmanx/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/wpebackend-rdk/1.20220924-r0/recipe-sysroot-native/usr/bin/arm-poky-linux-gnueabi/arm-poky-linux-gnueabi-gcc - skipped
| -- Detecting C compile features
| -- Detecting C compile features - done
| -- Detecting CXX compiler ABI info
| -- Detecting CXX compiler ABI info - done
| -- Check for working CXX compiler: /home/clopez/webkit/webkit/WebKitBuild/CrossToolChains/rpi3-dispmanx/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/wpebackend-rdk/1.20220924-r0/recipe-sysroot-native/usr/bin/arm-poky-linux-gnueabi/arm-poky-linux-gnueabi-g++ - skipped
| -- Detecting CXX compile features
| -- Detecting CXX compile features - done
| -- Found PkgConfig: /home/clopez/webkit/webkit/WebKitBuild/CrossToolChains/rpi3-dispmanx/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/wpebackend-rdk/1.20220924-r0/recipe-sysroot-native/usr/bin/pkg-config (found version "0.29.2")
| -- Checking for one of the modules 'wpe-1.0'
| -- Found WPE: /home/clopez/webkit/webkit/WebKitBuild/CrossToolChains/rpi3-dispmanx/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/wpebackend-rdk/1.20220924-r0/recipe-sysroot/usr/lib/libwpe-1.0.so (found version "1.14.0")
| -- Checking for module 'egl'
| --   Found egl, version 10
| -- Found EGL: /home/clopez/webkit/webkit/WebKitBuild/CrossToolChains/rpi3-dispmanx/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/wpebackend-rdk/1.20220924-r0/recipe-sysroot/usr/lib/libbrcmEGL.so
| -- Checking for module 'xkbcommon'
| --   Found xkbcommon, version 1.4.1
| -- Found Libxkbcommon: TRUE
| -- Checking for module 'glib-2.0'
| --   Found glib-2.0, version 2.72.3
| -- Found GLIB: /home/clopez/webkit/webkit/WebKitBuild/CrossToolChains/rpi3-dispmanx/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/wpebackend-rdk/1.20220924-r0/recipe-sysroot/usr/include/glib-2.0;/home/clopez/webkit/webkit/WebKitBuild/CrossToolChains/rpi3-dispmanx/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/wpebackend-rdk/1.20220924-r0/recipe-sysroot/usr/lib/glib-2.0/include (found suitable version "2.72.3", minimum required is "2.38.0")
| -- Checking for module 'libinput'
| --   Found libinput, version 1.19.4
| -- Found Libinput: TRUE
| -- Checking for module 'libudev'
| --   Found libudev, version 251
| CMake Error at /home/clopez/webkit/webkit/WebKitBuild/CrossToolChains/rpi3-dispmanx/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/wpebackend-rdk/1.20220924-r0/recipe-sysroot-native/usr/share/cmake-3.24/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
|   Could NOT find Libudev (missing: LIBUDEV_INCLUDE_DIRS)
| Call Stack (most recent call first):
|   /home/clopez/webkit/webkit/WebKitBuild/CrossToolChains/rpi3-dispmanx/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/wpebackend-rdk/1.20220924-r0/recipe-sysroot-native/usr/share/cmake-3.24/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
|   cmake/FindLibudev.cmake:41 (find_package_handle_standard_args)
|   CMakeLists.txt:83 (find_package)
| 
| 
| -- Configuring incomplete, errors occurred!
```

After this fix with the hints from `pkg-config` it is able to find the library:
```
[....]

-- Checking for module 'libudev'
--   Found libudev, version 251
-- Found Libudev: /home/clopez/webkit/webkit/WebKitBuild/CrossToolChains/rpi3-dispmanx/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/wpebackend-rdk/1.20220924-r0/recipe-sysroot/usr/include (found version "251") 
-- Checking for module 'bcm_host'
--   Found bcm_host, version 1
-- Found BCMHost: 1  
-- Found EGL: /home/clopez/webkit/webkit/WebKitBuild/CrossToolChains/rpi3-dispmanx/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/wpebackend-rdk/1.20220924-r0/recipe-sysroot/usr/lib/libbrcmEGL.so  
-- Configuring done
-- Generating done
```
