### PR TITLE
Update renderer-backend.cpp

### DIFF
--- a/src/wayland-egl/renderer-backend.cpp
+++ b/src/wayland-egl/renderer-backend.cpp
@@ -103,20 +103,26 @@ EGLTarget::EGLTarget(struct wpe_renderer_backend_egl_target* target, int hostFd)
 
 void EGLTarget::initialize(Backend& backend, uint32_t width, uint32_t height)
 {
+    uint32_t fullscreen = false;
+    char *tmp;
     m_backend = &backend;
     m_surface = wl_compositor_create_surface(m_backend->display.interfaces().compositor);
-
+    
     if (!m_surface) {
         fprintf(stderr, "EGLTarget: unable to create wayland surface\n");
         return;
     }
+    
+    if (tmp = std::getenv("WPE_INIT_VIEW_FULLSCREEN"))
+        fullscreen = atoi(tmp);
 
     if (m_backend->display.interfaces().shell) {
         m_shellSurface = wl_shell_get_shell_surface(m_backend->display.interfaces().shell, m_surface);
         if (m_shellSurface) {
             wl_shell_surface_add_listener(m_shellSurface,
                                           &shell_surface_listener, NULL);
-            // wl_shell_surface_set_toplevel(m_shellSurface);
+        wl_shell_surface_set_toplevel(m_shellSurface);
+        if (fullscreen)
             wl_shell_surface_set_fullscreen(m_shellSurface, WL_SHELL_SURFACE_FULLSCREEN_METHOD_DEFAULT, 0, NULL);
         }
     }


### PR DESCRIPTION
Adding support to toggle wl_shell_surface_set_fullscreen, by environment variable WPE_INIT_VIEW_FULLSCREEN. With wl_shell_surface_set_fullscreen enabled as default, it breaks dual-screen support in weston.