### PR TITLE
Add missing xkb headers for essos rendering backend

### DIFF
--- a/src/essos/renderer-backend.cpp
+++ b/src/essos/renderer-backend.cpp
@@ -25,6 +25,8 @@
 #include <linux/input.h>
 #include <essos-app.h>
 #include <essos-system.h>
+#include <xkbcommon/xkbcommon.h>
+#include <xkbcommon/xkbcommon-compose.h>
 
 #include "ipc.h"
 #include "ipc-essos.h"


### PR DESCRIPTION
Because xkb headers are no longer included by input-xkb.h