### PR TITLE
Fix wayland-egl build with GCC 13

### DIFF
--- a/src/wayland-egl/renderer-backend.cpp
+++ b/src/wayland-egl/renderer-backend.cpp
@@ -33,6 +33,7 @@
 #include "display.h"
 #include "ipc.h"
 #include "ipc-waylandegl.h"
+#include <cstdio>
 #include <wayland-client-protocol.h>
 
 namespace WaylandEGL {

--- a/src/wayland-egl/view-backend.cpp
+++ b/src/wayland-egl/view-backend.cpp
@@ -30,6 +30,7 @@
 #include "display.h"
 #include "ipc.h"
 #include "ipc-waylandegl.h"
+#include <cstdio>
 
 #define WIDTH 1280
 #define HEIGHT 720

--- a/src/wayland/display.cpp
+++ b/src/wayland/display.cpp
@@ -33,6 +33,7 @@
 #include "wayland-client-protocol.h"
 #include <cassert>
 #include <cstring>
+#include <cstdio>
 #include <glib.h>
 #include <linux/input.h>
 #include <locale.h>
@@ -40,6 +41,7 @@
 #include <stdlib.h>
 #include <sys/mman.h>
 #include <unistd.h>
+#include <xkbcommon/xkbcommon.h>
 #include <wayland-client.h>
 
 namespace Wayland {


### PR DESCRIPTION
Add missing headers to fix the build with GCC 13 and newer.