### PR TITLE
cmake: Fix Wayland include dirs

### DIFF
--- a/cmake/FindWayland.cmake
+++ b/cmake/FindWayland.cmake
@@ -41,6 +41,11 @@ pkg_check_modules(WAYLAND ${_WAYLAND_SERVER_MODE} wayland-client>=1.2 wayland-se
 find_library(WAYLAND_LIB NAMES wayland-client
         HINTS ${WAYLAND_LIBDIR} ${WAYLAND_LIBRARY_DIRS})
 
+# If Wayland includes are located in standard path i.e. "/usr/include" get this path manually to make next functions happy
+if(WAYLAND_INCLUDE_DIRS STREQUAL "")
+    pkg_get_variable(WAYLAND_INCLUDE_DIRS wayland-client includedir)
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Wayland DEFAULT_MSG WAYLAND_FOUND WAYLAND_INCLUDE_DIRS WAYLAND_LIBRARIES WAYLAND_LIB)
 mark_as_advanced(WAYLAND_INCLUDE_DIRS WAYLAND_LIBRARIES)

--- a/cmake/FindWaylandEGL.cmake
+++ b/cmake/FindWaylandEGL.cmake
@@ -41,6 +41,11 @@ pkg_check_modules(WAYLAND_EGL ${_WAYLAND_EGL_MODE} wayland-egl)
 find_library(WAYLAND_EGL_LIB NAMES wayland-egl
         HINTS ${WAYLAND_EGL_LIBDIR} ${WAYLAND_EGL_LIBRARY_DIRS})
 
+# If Wayland-EGL includes are located in standard path i.e. "/usr/include" get this path manually to make next functions happy
+if(WAYLAND_EGL_INCLUDE_DIRS STREQUAL "")
+    pkg_get_variable(WAYLAND_EGL_INCLUDE_DIRS wayland-egl includedir)
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(WaylandEGL DEFAULT_MSG WAYLAND_EGL_FOUND WAYLAND_EGL_INCLUDE_DIRS WAYLAND_EGL_LIBRARIES WAYLAND_EGL_LIB)
 set(WAYLAND_EGL_LIBRARIES ${WAYLAND_EGL_LIBRARIES} ${WAYLAND_EGL_LIB})


### PR DESCRIPTION
If Wayland includes are located in standard path i.e. "/usr/include" without any subdirectory, cmake function 'pkg_check_modules' will not set WAYLAND_INCLUDE_DIRS variable.
'pkg_check_modules' uses 'pkg-config --cflags-only-I' behind the scenes which ignores standard paths like "/usr/include".
When WAYLAND_INCLUDE_DIRS is empty, 'find_package_handle_standard_args' function complains about it.
To fix the issue, empty variable is detected first and then 'pkg_get_variable' function is used to get include dir path.