### PR TITLE
wayland: Fix repeat timeout computing

### DIFF
--- a/src/wayland/display.cpp
+++ b/src/wayland/display.cpp
@@ -285,7 +285,7 @@ repeatDelayTimeout(void* data)
 {
     auto& seatData = *static_cast<Display::SeatData*>(data);
     handleKeyEvent(seatData, seatData.repeatData.key, seatData.repeatData.state, seatData.repeatData.time);
-    seatData.repeatData.eventSource = g_timeout_add(seatData.repeatInfo.rate, static_cast<GSourceFunc>(repeatRateTimeout), data);
+    seatData.repeatData.eventSource = g_timeout_add(1000 / seatData.repeatInfo.rate, static_cast<GSourceFunc>(repeatRateTimeout), data);
     return G_SOURCE_REMOVE;
 }
 


### PR DESCRIPTION
In the wayland protocol, the rate parameter from the repeat_info event is defined as the rate of repeating keys in characters per second.

This is a frequency and not a timeout.