### PR TITLE
[VirtualInput] A package was renamed from ThunderVirtualInput to ClientVirtualInput

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,9 +53,9 @@ set(WPE_PLATFORM_LIBRARIES
         )
 
 if (USE_VIRTUAL_KEYBOARD)
-    find_package(ThunderVirtualInput REQUIRED)
+    find_package(ClientVirtualInput REQUIRED)
     list(APPEND WPE_PLATFORM_LIBRARIES
-        ThunderVirtualInput::ThunderVirtualInput
+        ClientVirtualInput::ClientVirtualInput
     )
     add_definitions(-DKEY_INPUT_HANDLING_VIRTUAL=1)
 endif()


### PR DESCRIPTION
In the last [commit](https://github.com/rdkcentral/ThunderClientLibraries/commit/5bd15182c0fb164be54e9ae951ef5fba29eebae8#diff-bd9054b1a4f18091b2cfa2378e0743f19b1c2f0f9ef24b3b38c3703a486f587b) to ThunderClientLibraries, the ThunderVirtualInput package was rename to ClientVirtualInput